### PR TITLE
added error checking in Look_for variable collection

### DIFF
--- a/greprow.sh
+++ b/greprow.sh
@@ -34,7 +34,7 @@ next_Search () {
     next_Step
 }
 
-#function to ask user if they would like to define their own file path, if not, the program declares greprow2/log.txt as input
+#function to ask user if they would like to define their own file path, if not, the program declares greprow/log.txt as input
 #yes_no () {
 #dialog --title "Define your own file/path?" \
 #--yesno "If you select no, $PWD/log.txt will be used." 7 60
@@ -74,19 +74,22 @@ case $answer in
                    inputPath="$PWD/log.txt"
                    ;;
 
-            * ) echo "Invalid input"
-                continue
-		;;
+               * ) 
+	           echo "Invalid input"
+                   continue
+                   ;;
 esac
 }
 
 #this function collects the variable that is used to search the specified file and stores it as lookFor
 what_Find () {  
     echo "	"
-    echo -n "What information would you like to find? "
-        read lookFor
+    
+    echo -n "What information would you like to find? (Do not use a Space if asking for a name.) "    
+        read Look_for
+	Look_for="$(echo -e "${Look_for}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
     echo "	"
-    echo "Looking for $lookFor... Please wait... "
+    echo "Looking for $Look_For... Please wait... "
     echo "Search Start Time : " $(date -u)
     printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' -
 }
@@ -96,10 +99,10 @@ grep_Append () {
 ###DO NOT TOUCH!!!! THIS SHOULDNT WORK, SO THEREFORE ITS PERFECTLY BROKEN AS IS!!!!###
 while : 
  do
-     grep -i $lookFor $inputPath >> $lookFor.txt 
+     grep -i $Look_for $inputPath >> $Look_for.txt 
      if [ $? -eq 0 ] ; then
        echo "	"
-       echo "$lookFor found and writing to file, check current directory for $lookFor.txt"
+       echo "$Look_for found and writing to file, check current directory for $Look_For.txt"
        echo "Search ended at " $(date -u)
        printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' -
        break

--- a/greprow.sh
+++ b/greprow.sh
@@ -97,6 +97,23 @@ what_Find () {
 grep_Append () {
 #I dont know why this works, how or if it even should.  This while statement shows my naivety to bash scripting though.
 ###DO NOT TOUCH!!!! THIS SHOULDNT WORK, SO THEREFORE ITS PERFECTLY BROKEN AS IS!!!!###
+
+#okay so its time to implement some error checks of sorts
+
+#The -n operator checks whether the string is not null.
+#Effectively, this will return true for every case except where the string contains no characters. ie:
+#VAR="hello"
+#if [ -n "$VAR" ]; then
+#    echo "VAR is not empty"
+#fi
+
+##Similarly, the -z operator checks whether the string is null. ie:
+# VAR=""
+#if [ -z "$VAR" ]; then
+#   echo "VAR is empty"
+#fi
+
+
 while : 
  do
      grep -i $Look_for2 $inputPath >> $Look_for2.txt 

--- a/greprow.sh
+++ b/greprow.sh
@@ -71,6 +71,24 @@ what_Find () {
 grep_Append () {
 #I dont know why this works, how or if it even should.  This while statement shows my naivety to bash scripting though.
 ###DO NOT TOUCH!!!! THIS SHOULDNT WORK, SO THEREFORE ITS PERFECTLY BROKEN AS IS!!!!###
+
+#okay so its time to implement some error checks of sorts
+
+#The -n operator checks whether the string is not null.
+#Effectively, this will return true for every case except where the string contains no characters. ie:
+#VAR="hello"
+#if [ -n "$VAR" ]; then
+#    echo "VAR is not empty"
+#fi
+
+##Similarly, the -z operator checks whether the string is null. ie:
+# VAR=""
+#if [ -z "$VAR" ]; then
+#   echo "VAR is empty"
+#fi
+
+
+
 while : 
  do
      grep -i $lookFor $inputPath >> $lookFor.txt 

--- a/greprow.sh
+++ b/greprow.sh
@@ -87,9 +87,9 @@ what_Find () {
     
     echo -n "What information would you like to find? (Do not use a Space if asking for a name.) "    
         read Look_for
-	Look_for="$(echo -e "${Look_for}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+	Look_for2="$(echo -e "${Look_for}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
     echo "	"
-    echo "Looking for $Look_For... Please wait... "
+    echo "Looking for $Look_For2... Please wait... "
     echo "Search Start Time : " $(date -u)
     printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' -
 }
@@ -99,7 +99,7 @@ grep_Append () {
 ###DO NOT TOUCH!!!! THIS SHOULDNT WORK, SO THEREFORE ITS PERFECTLY BROKEN AS IS!!!!###
 while : 
  do
-     grep -i $Look_for $inputPath >> $Look_for.txt 
+     grep -i $Look_for2 $inputPath >> $Look_for2.txt 
      if [ $? -eq 0 ] ; then
        echo "	"
        echo "$Look_for found and writing to file, check current directory for $Look_For.txt"


### PR DESCRIPTION
May or may not work, don't have my Linux box up and running atm to check.  My goal is to pull all the blank space out of the variable when its collected to help with the searching function and also the file creation.  Users are silly, and I don't think writing "Don't use a space" will always help.